### PR TITLE
fix for version NIfTI 0.6.1

### DIFF
--- a/src/Arrays.jl
+++ b/src/Arrays.jl
@@ -35,11 +35,10 @@ function makeAxisArray(array::Array{T,3}, pixelspacing, offset) where T
   return im
 end
 
-function makeAxisArray(I::AbstractArray{T,6}, spacing::Vector{Float64}) where T
-
+function makeAxisArray(I::AbstractArray{T,6}, spacing) where T
   offset = [0.0, 0.0, 0.0]*Unitful.mm
 
-  sp = uconvert.(Unitful.mm, spacing*Unitful.m)
+  sp = uconvert.(Unitful.mm, spacing.*Unitful.m)
 
   im = AxisArray(I,
 		   Axis{:x}(range(offset[1], step=sp[1], length=size(I,1))),

--- a/test/Coloring.jl
+++ b/test/Coloring.jl
@@ -74,8 +74,8 @@ exportImage("img/coloring7.png", Y)
 
 # normalizeGray
 colormap = ImageUtils.ColorSchemes.phase
-@test ImageUtils.normalizeGray(colormap[1]) == RGB{Float64}(0.8979049716100672,0.6795060499249219,0.28645928277939586)
-@test @test_logs (:warn,"Normalization of gray value failed, g ≈ 0.056 is used. Use g >= 0.056 for a consistent normalization.") match_mode=:any ImageUtils.normalizeGray(colormap[1],0.05) == RGB{Float64}(0.18396207457891003,0.0,0.0)
-@test @test_logs (:warn,"Normalization of gray value failed, g ≈ 0.925 is used. Use g <= 0.925 for a consistent normalization.") match_mode=:any ImageUtils.normalizeGray(colormap[1],0.95) == RGB{Float64}(1.0,0.9603124734843839,0.5548057892335283)
+@test isapprox(ImageUtils.normalizeGray(colormap[1]),RGB{Float64}(0.8979049716100672,0.6795060499249219,0.28645928277939586))
+@test @test_logs (:warn,"Normalization of gray value failed, g ≈ 0.056 is used. Use g >= 0.056 for a consistent normalization.") match_mode=:any isapprox(ImageUtils.normalizeGray(colormap[1],0.05),RGB{Float64}(0.18396207457891003,0.0,0.0))
+@test @test_logs (:warn,"Normalization of gray value failed, g ≈ 0.925 is used. Use g <= 0.925 for a consistent normalization.") match_mode=:any isapprox(ImageUtils.normalizeGray(colormap[1],0.95),RGB{Float64}(1.0,0.9603124734843839,0.5548057892335283))
 
 end

--- a/test/IO.jl
+++ b/test/IO.jl
@@ -1,0 +1,26 @@
+using ImageUtils.AxisArrays
+using ImageUtils.Unitful
+using ImageUtils.NIfTI
+@testset "IO tests" begin
+
+  a = zeros(Float32,10,20,30,1,2,3)
+
+  N = size(a)
+  pixelspacing_q = (1,1,1).*u"mm"
+  offset=(0,0,0).*u"mm"
+  a = AxisArray(a, Axis{:color}(1:N[1]),
+		 Axis{:x}(range(offset[1],step=pixelspacing_q[1],length=N[2])),
+		 Axis{:y}(range(offset[2],step=pixelspacing_q[2],length=N[3])),
+		 Axis{:z}(range(offset[3],step=pixelspacing_q[3],length=N[4])))
+
+  filename_nii = "test.nii"
+  saveImage(filename_nii, a)
+  b = loadImage(filename_nii)
+  @test a == b
+
+  # nifti version <= 0.6.0
+  ni = niread(filename_nii)
+  pixelspacing = voxel_size(ni.header)
+  c = makeAxisArray(ni.raw, [pixelspacing...])
+  @test a == c
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -19,3 +19,4 @@ end
 include("Coloring.jl")
 include("Slicing.jl")
 include("Transformation.jl")
+include("IO.jl")


### PR DESCRIPTION
related to https://github.com/MagneticResonanceImaging/MRIReco.jl/pull/222 and the release 0.6.1 of NIfTI.jl : https://github.com/JuliaNeuroscience/NIfTI.jl/releases/tag/v0.6.1